### PR TITLE
feat: longer reminder length + memory conservation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,23 +1,23 @@
 {
   "name": "reminders",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "reminders",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
-        "@sentry/node": "^8.9.2",
+        "@sentry/node": "^8.10.0",
         "discord.js": "^14.15.3",
         "dotenv": "^16.4.5",
-        "mongoose": "^8.4.1"
+        "mongoose": "^8.4.3"
       },
       "devDependencies": {
-        "@sentry/types": "^8.9.2",
-        "@types/node": "^20.14.2",
-        "typescript": "^5.4.5"
+        "@sentry/types": "^8.10.0",
+        "@types/node": "^20.14.7",
+        "typescript": "^5.5.2"
       }
     },
     "node_modules/@discordjs/builders": {
@@ -830,9 +830,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.14.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.6.tgz",
-      "integrity": "sha512-JbA0XIJPL1IiNnU7PFxDXyfAwcwVVrOoqyzzyQTyMeVhBzkJVMSkC1LlVsRQ2lpqiY4n6Bb9oCS6lzDKVQxbZw==",
+      "version": "20.14.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.7.tgz",
+      "integrity": "sha512-uTr2m2IbJJucF3KUxgnGOZvYbN0QgkGyWxG6973HCpMYFy2KfcgYuIwkJQMQkt1VbBMlvWRbpshFTLxnxCZjKQ==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -1420,10 +1420,11 @@
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/typescript": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
-      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.2.tgz",
+      "integrity": "sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reminders",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Set reminders for things you need to do.",
   "main": "dist/index.js",
   "scripts": {
@@ -18,14 +18,14 @@
   },
   "homepage": "https://github.com/wdhdev/reminders#readme",
   "dependencies": {
-    "@sentry/node": "^8.9.2",
+    "@sentry/node": "^8.10.0",
     "discord.js": "^14.15.3",
     "dotenv": "^16.4.5",
-    "mongoose": "^8.4.1"
+    "mongoose": "^8.4.3"
   },
   "devDependencies": {
-    "@sentry/types": "^8.9.2",
-    "@types/node": "^20.14.2",
-    "typescript": "^5.4.5"
+    "@sentry/types": "^8.10.0",
+    "@types/node": "^20.14.7",
+    "typescript": "^5.5.2"
   }
 }

--- a/src/classes/ExtendedClient.ts
+++ b/src/classes/ExtendedClient.ts
@@ -10,6 +10,7 @@ export default class ExtendedClient extends Client {
     public events: Collection<string, any>;
     public logCommandError: Function;
     public logError: Function;
+    public maxTime: number;
     public reminders: Map<string, NodeJS.Timeout>;
     public sentry: typeof Sentry;
     public validPermissions: string[];

--- a/src/classes/ExtendedClient.ts
+++ b/src/classes/ExtendedClient.ts
@@ -10,8 +10,9 @@ export default class ExtendedClient extends Client {
     public events: Collection<string, any>;
     public logCommandError: Function;
     public logError: Function;
-    public maxTime: number;
+    public maxReminderTime: number;
     public reminders: Map<string, NodeJS.Timeout>;
     public sentry: typeof Sentry;
+    public timeToSet: number;
     public validPermissions: string[];
 }

--- a/src/commands/reminders/remindme.ts
+++ b/src/commands/reminders/remindme.ts
@@ -26,13 +26,6 @@ const command: Command = {
             min_length: 2,
             max_length: 16,
             required: true
-        },
-
-        {
-            type: 5,
-            name: "return_id",
-            description: "Whether to include the reminder ID in the response.",
-            required: false
         }
     ],
     default_member_permissions: null,
@@ -45,14 +38,13 @@ const command: Command = {
         try {
             const reason = interaction.options.get("reason").value as string;
             let time: number | string = interaction.options.get("time").value as string;
-            const returnId = interaction.options.get("return_id")?.value || false;
 
             const reminders = await Reminder.find({ user: interaction.user.id });
 
-            if(reminders.length >= 5) {
+            if(reminders.length >= 10) {
                 const error = new Discord.EmbedBuilder()
                     .setColor(client.config_embeds.error)
-                    .setDescription(`${emoji.cross} You can only have up to 5 active reminders at once!`)
+                    .setDescription(`${emoji.cross} You can only have up to 10 active reminders at once!`)
 
                 await interaction.editReply({ embeds: [error] });
                 return;
@@ -76,18 +68,16 @@ const command: Command = {
             const minutes = match[3] ? parseInt(match[3]) : 0;
             const seconds = match[4] ? parseInt(match[4]) : 0;
 
-            time = days * 24 * 60 * 60 * 1000 + hours * 60 * 60 * 1000 + minutes * 60 * 1000 + seconds * 1000;
+            time = (days * 24 * 60 * 60 * 1000) + (hours * 60 * 60 * 1000) + (minutes * 60 * 1000) + (seconds * 1000);
 
-            const maxTime = 24 * 60 * 60 * 1000 * 24;
+            // if(time > client.maxTime) {
+            //     const error = new Discord.EmbedBuilder()
+            //         .setColor(client.config_embeds.error)
+            //         .setDescription(`${emoji.cross} Your reminder cannot be more than 24 days in the future.`)
 
-            if(time > maxTime) {
-                const error = new Discord.EmbedBuilder()
-                    .setColor(client.config_embeds.error)
-                    .setDescription(`${emoji.cross} Your reminder cannot be more than 24 days in the future.`)
-
-                await interaction.editReply({ embeds: [error] });
-                return;
-            }
+            //     await interaction.editReply({ embeds: [error] });
+            //     return;
+            // }
 
             const id = randomUUID().slice(0, 8) as string;
 
@@ -102,36 +92,38 @@ const command: Command = {
                 reason: reason
             }).save()
 
-            client.reminders.set(`${interaction.user.id}-${id}`, setTimeout(async () => {
-                const embed = new Discord.EmbedBuilder()
-                    .setColor(client.config_embeds.default)
-                    .setTitle("Reminder")
-                    .setDescription(reason)
-                    .addFields (
-                        { name: "Set", value: `<t:${reminder.set.toString().slice(0, -3)}:f> (<t:${reminder.set.toString().slice(0, -3)}:R>)` }
-                    )
-                    .setFooter({ text: `ID: ${reminder.reminder_id}` })
-                    .setTimestamp()
+            if(time < client.maxTime) {
+                client.reminders.set(`${interaction.user.id}-${id}`, setTimeout(async () => {
+                    const embed = new Discord.EmbedBuilder()
+                        .setColor(client.config_embeds.default)
+                        .setTitle("Reminder")
+                        .setDescription(reason)
+                        .addFields (
+                            { name: "Set", value: `<t:${reminder.set.toString().slice(0, -3)}:f> (<t:${reminder.set.toString().slice(0, -3)}:R>)` }
+                        )
+                        .setFooter({ text: `ID: ${reminder.reminder_id}` })
+                        .setTimestamp()
 
-                try {
-                    await interaction.user.send({ embeds: [embed] });
-                } catch {
                     try {
-                        const channel = client.channels.cache.get(interaction.channel.id) as TextChannel;
+                        await interaction.user.send({ embeds: [embed] });
+                    } catch {
+                        try {
+                            const channel = client.channels.cache.get(interaction.channel.id) as TextChannel;
 
-                        if(!channel) return;
+                            if(!channel) return;
 
-                        await channel.send({ content: `${interaction.user}`, embeds: [embed] });
-                    } catch {}
-                }
+                            await channel.send({ content: `${interaction.user}`, embeds: [embed] });
+                        } catch {}
+                    }
 
-                client.reminders.delete(`${interaction.user.id}-${id}`);
-                await Reminder.findOneAndDelete({ reminder_id: id, user: interaction.user.id });
-            }, time))
+                    client.reminders.delete(`${interaction.user.id}-${id}`);
+                    await Reminder.findOneAndDelete({ reminder_id: id, user: interaction.user.id });
+                }, time))
+            }
 
             const reminderSet = new Discord.EmbedBuilder()
                 .setColor(client.config_embeds.default)
-                .setDescription(`${emoji.tick} Your reminder has been set for <t:${reminder.due.toString().slice(0, -3)}:f>${returnId ? ` with the ID \`${reminder.reminder_id}\`` : ""}!`)
+                .setDescription(`${emoji.tick} Your reminder has been set for <t:${reminder.due.toString().slice(0, -3)}:f> with ID \`${reminder.reminder_id}\`!`)
 
             await interaction.editReply({ embeds: [reminderSet] });
         } catch(err) {

--- a/src/events/client/ready.ts
+++ b/src/events/client/ready.ts
@@ -6,6 +6,7 @@ import { exec } from "child_process";
 import globalCommands from "../../scripts/global-commands";
 
 import Reminder from "../../models/Reminder";
+import setReminder from "../../util/setReminder";
 
 const event: Event = {
     name: "ready",
@@ -30,64 +31,24 @@ const event: Event = {
             }, 30 * 1000) // 30 seconds
 
             // Manage timeouts
-            let reminders = await Reminder.find({});
+            const setReminders: string[] = [];
 
-            const dueReminders = reminders.filter(reminder => reminder.due <= Date.now().toString());
+            async function manageExistingTimeouts() {
+                let reminders = await Reminder.find({});
 
-            for(const reminder of dueReminders) {
-                // if(!client.guilds.cache.has(reminder.guild)) {
-                //     await reminder.deleteOne();
-                //     reminders = reminders.filter(r => r !== reminder);
-                //     continue;
-                // }
+                const dueReminders = reminders.filter(reminder => reminder.due <= Date.now().toString());
 
-                await reminder.deleteOne();
-                reminders = reminders.filter(r => r !== reminder);
-
-                const embed = new Discord.EmbedBuilder()
-                    .setColor(client.config_embeds.default)
-                    .setTitle("Overdue Reminder")
-                    .setDescription(reminder.reason)
-                    .addFields (
-                        { name: "Set", value: `<t:${reminder.set.toString().slice(0, -3)}:f>`, inline: true },
-                        { name: "Overdue Since", value: `<t:${reminder.due.toString().slice(0, -3)}:R>`, inline: true }
-                    )
-                    .setFooter({ text: `ID: ${reminder.reminder_id}` })
-                    .setTimestamp()
-
-                try {
-                    const user = client.users.cache.get(reminder.user);
-
-                    await user.send({ embeds: [embed] });
-                } catch {
-                    try {
-                        const channel = client.channels.cache.get(reminder.channel) as Discord.TextChannel;
-
-                        if(!channel) return;
-
-                        await channel.send({ content: `<@${reminder.user}>`, embeds: [embed] });
-                    } catch {}
-                }
-            }
-
-            for(const reminder of reminders) {
-                // if(!client.guilds.cache.has(reminder.guild)) {
-                //     await reminder.deleteOne();
-                //     continue;
-                // }
-
-                const delay = Number(reminder.due) - Date.now();
-
-                client.reminders.set(`${reminder.user}-${reminder.reminder_id}`, setTimeout(async () => {
+                for(const reminder of dueReminders) {
                     await reminder.deleteOne();
-                    client.reminders.delete(`${reminder.user}-${reminder.reminder_id}`);
+                    reminders = reminders.filter(r => r !== reminder);
 
                     const embed = new Discord.EmbedBuilder()
                         .setColor(client.config_embeds.default)
-                        .setTitle("Reminder")
+                        .setTitle("Overdue Reminder")
                         .setDescription(reminder.reason)
                         .addFields (
-                            { name: "Set", value: `<t:${reminder.set.toString().slice(0, -3)}:f>` }
+                            { name: "Set", value: `<t:${reminder.set.toString().slice(0, -3)}:f>`, inline: true },
+                            { name: "Overdue Since", value: `<t:${reminder.due.toString().slice(0, -3)}:R>`, inline: true }
                         )
                         .setFooter({ text: `ID: ${reminder.reminder_id}` })
                         .setTimestamp()
@@ -105,8 +66,30 @@ const event: Event = {
                             await channel.send({ content: `<@${reminder.user}>`, embeds: [embed] });
                         } catch {}
                     }
-                }, delay))
+                }
+
+                for(const reminder of reminders) {
+                    const result = await setReminder(reminder, client);
+
+                    if(result) setReminders.push(`${reminder.user}-${reminder.reminder_id}`);
+                }
             }
+
+            manageExistingTimeouts().then(async () => {
+                setInterval(async () => {
+                    const reminders = await Reminder.find({});
+
+                    if(reminders.length === 0) return;
+
+                    for(const reminder of reminders) {
+                        if(setReminders.includes(`${reminder.user}-${reminder.reminder_id}`)) continue;
+
+                        const result = await setReminder(reminder, client);
+
+                        if(result) setReminders.push(`${reminder.user}-${reminder.reminder_id}`);
+                    }
+                }, 60000)
+            })
         } catch(err) {
             client.logError(err);
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,7 @@ client.login(process.env.token);
 
 // Constants
 client.commandIds = new Discord.Collection();
+client.maxTime = 10 * 60 * 1000; // 10 minutes
 client.reminders = new Map();
 client.sentry = Sentry;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,9 +47,11 @@ client.login(process.env.token);
 
 // Constants
 client.commandIds = new Discord.Collection();
-client.maxTime = 10 * 60 * 1000; // 10 minutes
 client.reminders = new Map();
 client.sentry = Sentry;
+
+client.maxReminderTime = 365 * 24 * 60 * 60 * 1000; // 1 year (365 days)
+client.timeToSet = 10 * 60 * 1000; // 10 minutes
 
 client.validPermissions = [
     "CreateInstantInvite",

--- a/src/util/setReminder.ts
+++ b/src/util/setReminder.ts
@@ -4,7 +4,7 @@ import ExtendedClient from "../classes/ExtendedClient";
 export default async function (reminder: any, client: ExtendedClient): Promise<Boolean> {
     const delay = Number(reminder.due) - Date.now();
 
-    if(delay > client.maxTime) return false;
+    if(delay > client.timeToSet) return false;
 
     client.reminders.set(`${reminder.user}-${reminder.reminder_id}`, setTimeout(async () => {
         await reminder.deleteOne();

--- a/src/util/setReminder.ts
+++ b/src/util/setReminder.ts
@@ -1,0 +1,39 @@
+import Discord from "discord.js";
+import ExtendedClient from "../classes/ExtendedClient";
+
+export default async function (reminder: any, client: ExtendedClient): Promise<Boolean> {
+    const delay = Number(reminder.due) - Date.now();
+
+    if(delay > client.maxTime) return false;
+
+    client.reminders.set(`${reminder.user}-${reminder.reminder_id}`, setTimeout(async () => {
+        await reminder.deleteOne();
+        client.reminders.delete(`${reminder.user}-${reminder.reminder_id}`);
+
+        const embed = new Discord.EmbedBuilder()
+            .setColor(client.config_embeds.default)
+            .setTitle("Reminder")
+            .setDescription(reminder.reason)
+            .addFields (
+                { name: "Set", value: `<t:${reminder.set.toString().slice(0, -3)}:f>` }
+            )
+            .setFooter({ text: `ID: ${reminder.reminder_id}` })
+            .setTimestamp()
+
+        try {
+            const user = client.users.cache.get(reminder.user);
+
+            await user.send({ embeds: [embed] });
+        } catch {
+            try {
+                const channel = client.channels.cache.get(reminder.channel) as Discord.TextChannel;
+
+                if(!channel) return;
+
+                await channel.send({ content: `<@${reminder.user}>`, embeds: [embed] });
+            } catch {}
+        }
+    }, delay))
+
+    return true;
+}


### PR DESCRIPTION
- Allow unlimited reminder lengths *technically*, however they are limited on the command to 365 days.
- Conserve memory by only calling `setTimeout` 10 minutes before the reminder is due
- Remove the `return_id` option from the `/remindme` command (it is now returned by default)